### PR TITLE
#2 Added `.performUnsafeOperation(_:)`

### DIFF
--- a/Sources/Atomic/Atomic.swift
+++ b/Sources/Atomic/Atomic.swift
@@ -17,10 +17,10 @@ import Dispatch
 public struct Atomic<WrappedValue> {
     
     /// The value which should only be read from one thread at a time
-    private var threadUnsafeValue: WrappedValue
+    fileprivate var threadUnsafeValue: WrappedValue
     
     /// The queue which will ensure only one thread will be able to read the value at a time
-    private var exclusiveAccessQueue: DispatchQueue
+    fileprivate var exclusiveAccessQueue: DispatchQueue
     
     /// Safely accesses the unsafe value from within the context of its exclusive-access queue
     public var wrappedValue: WrappedValue {
@@ -42,6 +42,27 @@ public struct Atomic<WrappedValue> {
         self.threadUnsafeValue = wrappedValue
         self.exclusiveAccessQueue = queue
     }
+}
+
+
+
+public extension Atomic {
+    
+    /// Allows you to manually perform some operation(s) on the wrapepd value directly without the safety layer around
+    /// it. It is still guarded by the exclusive access queue outside this call, but inside it you may do anything you
+    /// want for as long as you want with as many accessors as you want.
+    ///
+    /// - Parameter operator: The function which will perform the operation(s)
+    mutating func performUnsafeOperation(_ operator: UnsafeOperator) {
+        exclusiveAccessQueue.sync {
+            `operator`(&threadUnsafeValue)
+        }
+    }
+    
+    
+    
+    /// A kind of function which operates on a value
+    typealias UnsafeOperator = (inout WrappedValue) -> Void
 }
 
 


### PR DESCRIPTION
This resolves #2